### PR TITLE
Improve documentation for using private registries

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -204,13 +204,13 @@ EOF
 sudo systemctl restart k3s
 ```
 
-If this is successfully applied, you can check the applied configuration in the `config.registry` section of the following command. Be sure to use the `crictl` binary from k3s, otherwise you won't see your changes reflected in the `containerd` configuration used by k3s.
+If this is successfully applied, you can check the applied configuration in the `config.registry` section of the following command.
 
 ```bash
-sudo k3s crictl info
+sudo /usr/local/bin/k3s crictl info
 
 # With jq
-sudo k3s crictl info | jq .config.registry
+sudo /usr/local/bin/k3s crictl info | jq .config.registry
 ```
 
 If you want Kubernetes to be able to pull images directly from this private registry, alternatively you can also manually create `imagePullSecrets` for the Pod instead of writing your credentials in `auth` in `registries.yaml`. [Another guide about rate limiting on Docker Hub](../tips/dockerhub-rate-limit.md) explains how to use `ImagePullSecrets`.

--- a/registry/README.md
+++ b/registry/README.md
@@ -204,13 +204,13 @@ EOF
 sudo systemctl restart k3s
 ```
 
-If this is successfully applied, you can check the applied configuration in the `config.registry` section of the following command.
+If this is successfully applied, you can check the applied configuration in the `config.registry` section of the following command. Be sure to use the `crictl` binary from k3s, otherwise you won't see your changes reflected in the `containerd` configuration used by k3s.
 
 ```bash
-sudo /usr/local/bin/crictl info
+sudo k3s crictl info
 
 # With jq
-sudo /usr/local/bin/crictl info | jq .config.registry
+sudo k3s crictl info | jq .config.registry
 ```
 
 If you want Kubernetes to be able to pull images directly from this private registry, alternatively you can also manually create `imagePullSecrets` for the Pod instead of writing your credentials in `auth` in `registries.yaml`. [Another guide about rate limiting on Docker Hub](../tips/dockerhub-rate-limit.md) explains how to use `ImagePullSecrets`.


### PR DESCRIPTION
When updating k3s private registries configuration (under /etc/rancher/k3s/registries.yaml), one has to use the k3s crictl binary to verify the changes done to the containerd configuration.