### PR TITLE
fix: add workaround to suppress certain errors

### DIFF
--- a/base/dockerconfig.json
+++ b/base/dockerconfig.json
@@ -1,0 +1,8 @@
+{
+    "auths": {
+        "dummy.example.com": {
+            "username": "you_do_not_need_to_edit_this_file",
+            "password": "this_file_is_used_in_workaround_to_suppress_certain_errors"
+        }
+    }
+}

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -28,6 +28,13 @@ secretGenerator:
     literals:
       - password=Ansible123!
 
+  # Temporary workaround to suppress errors from AWX Operator 0.21.0.
+  # Refer: https://github.com/kurokobo/awx-on-k3s/issues/74
+  - name: redhat-operators-pull-secret
+    files:
+      - .dockerconfigjson=dockerconfig.json
+    type: kubernetes.io/dockerconfigjson
+
 resources:
   - pv.yaml
   - pvc.yaml


### PR DESCRIPTION
Related: #74 

AWX Operator's Deployment uses the secret called `redhat-operators-pull-secret` as `imagePullSecrets`, that is not present by default. Immediately after deploying AWX Operator, the error described in #74 will be logged on `/var/log/messages`, but the error can be ignored. 

To suppress errors about this secret not being found, this commit create a dummy secret, although it is never actually used. With this workaround, errors are no longer logged once AWX is deployed.