### PR TITLE
feat: bump pulp operator version to 1.0.0-alpha.2

### DIFF
--- a/galaxy/pulp/galaxy.yaml
+++ b/galaxy/pulp/galaxy.yaml
@@ -1,13 +1,15 @@
-apiVersion: pulp.pulpproject.org/v1beta1
+apiVersion: repo-manager.pulpproject.org/v1alpha1
 kind: Pulp
 metadata:
   name: galaxy
 spec:
   # These parameters are designed for use with:
-  # - Pulp Operator: 0.14.1
-  #   https://github.com/pulp/pulp-operator/blob/0.14.1/README.md
+  # - Pulp Operator: 1.0.0-alpha.2
+  #   https://github.com/pulp/pulp-operator/blob/1.0.0-alpha.2/README.md
   # - Galaxy NG: 4.5.2
   #   https://github.com/ansible/galaxy_ng/tree/4.5.2
+
+  deployment_type: galaxy
 
   image: quay.io/pulp/galaxy
   image_version: 4.5.2
@@ -16,29 +18,36 @@ spec:
 
   admin_password_secret: galaxy-admin-password
 
-  ingress_type: ingress
-  ingress_tls_secret: galaxy-secret-tls
-  hostname: galaxy.example.com
-
-  postgres_storage_class: galaxy-postgres-volume
-  postgres_storage_requirements:
-    requests:
-      storage: 8Gi
-  redis_storage_class: galaxy-redis-volume
+  # As a workaround for 1.0.0-alpha.2,
+  # to force use TLS termination on Ingress and to force to deploy Pulp Web container,
+  # keep ingress_type empty and deploy ingress without using Operator.
+  # I believe this can be back in the next release.
+  # https://github.com/pulp/pulp-operator/issues/676
+  # https://github.com/pulp/pulp-operator/issues/770
+  #ingress_type: ingress
+  #ingress_tls_secret: galaxy-secret-tls
+  #ingress_host: galaxy.example.com
 
   storage_type: file
-  file_storage_storage_class: galaxy-pulp-volume
+  file_storage_storage_class: galaxy-file-volume
   file_storage_access_mode: ReadWriteOnce
   file_storage_size: 8Gi
 
   pulp_settings:
+    ANSIBLE_API_HOSTNAME: https://galaxy.example.com
+    CONTENT_ORIGIN: https://galaxy.example.com
     TOKEN_AUTH_DISABLED: "True"
 
   api:
     replicas: 1
+  cache:
+    redis_storage_class: galaxy-redis-volume
   content:
     replicas: 1
-  worker:
-    replicas: 1
+  database:
+    postgres_storage_class: galaxy-database-volume
+    postgres_storage_requirements: 8Gi
   web:
+    replicas: 1
+  worker:
     replicas: 1

--- a/galaxy/pulp/ingress.yaml
+++ b/galaxy/pulp/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: galaxy-ingress
+  name: galaxy
 spec:
   tls:
     - hosts:
@@ -16,6 +16,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: galaxy-service
+                name: galaxy-web-svc
                 port:
-                  number: 80
+                  number: 24880

--- a/galaxy/pulp/kustomization.yaml
+++ b/galaxy/pulp/kustomization.yaml
@@ -16,11 +16,12 @@ secretGenerator:
   - name: galaxy-postgres-configuration
     type: Opaque
     literals:
-      - host=galaxy-postgres-13
+      - host=galaxy-database-svc
       - port=5432
       - database=galaxy
       - username=galaxy
       - password=Galaxy123!
+      - sslmode=prefer
       - type=managed
 
   - name: galaxy-admin-password
@@ -30,4 +31,5 @@ secretGenerator:
 
 resources:
   - pv.yaml
+  - ingress.yaml
   - galaxy.yaml

--- a/galaxy/pulp/pv.yaml
+++ b/galaxy/pulp/pv.yaml
@@ -2,31 +2,31 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: galaxy-postgres-volume
+  name: galaxy-database-volume
 spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   capacity:
     storage: 8Gi
-  storageClassName: galaxy-postgres-volume
+  storageClassName: galaxy-database-volume
   hostPath:
-    path: /data/galaxy/postgres-13
+    path: /data/galaxy/database
 
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: galaxy-pulp-volume
+  name: galaxy-file-volume
 spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   capacity:
     storage: 8Gi
-  storageClassName: galaxy-pulp-volume
+  storageClassName: galaxy-file-volume
   hostPath:
-    path: /data/galaxy/pulp
+    path: /data/galaxy/file
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Closes: #140 

Updated deployment procedure is a bit tricky due to several issues of Pulp Operator.
I believe they will be reverted in the next release.