### PR TITLE
Adding on documentation the curl dependencie to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ reboot
 Install required packages to deploy AWX Operator and AWX.
 
 ```bash
-sudo dnf install -y git make
+sudo dnf install -y git make curl
 ```
 
 ### Install K3s


### PR DESCRIPTION
Im use your instructions to install and looks like they forget to add the curl dependencie:

![image](https://user-images.githubusercontent.com/60560085/209245236-bc566c30-905e-45e6-a513-64a12e99e322.png)
