### PR TITLE
updated README required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo reboot
 Install required packages to deploy AWX Operator and AWX.
 
 ```bash
-sudo dnf install -y git make curl
+sudo dnf install -y git make curl tar
 ```
 
 ### Install K3s


### PR DESCRIPTION
It seems CentOS 8 Stream does not come with tar installed. When trying to run the make deploy for the operator on a fresh minimal (as required) installation of CentOS 8 Stream the process fails missing the command "tar"