### PR TITLE
Add default realm to example krb5.conf

### DIFF
--- a/tips/use-kerberos.md
+++ b/tips/use-kerberos.md
@@ -144,10 +144,10 @@ This is my example. Note that some domain names under `[realms]` and `[domain_re
 
 ```ini
 [libdefaults]
+  default_realm = KUROKOBO.INTERNAL
   dns_lookup_realm = false
   dns_lookup_kdc = false
   rdns = false
-  default_realm = KUROKOBO.INTERNAL
 
 [realms]
   KUROKOBO.INTERNAL = {
@@ -180,6 +180,7 @@ apiVersion: v1
 data:
   krb5.conf: |-
     [libdefaults]
+      default_realm = KUROKOBO.INTERNAL
       dns_lookup_realm = false
       dns_lookup_kdc = false
       rdns = false
@@ -368,6 +369,7 @@ If your Container Group and ConfigMap are configured correctly, you can get your
 ```bash
 bash-5.1$ cat /etc/krb5.conf
 [libdefaults]
+  default_realm = KUROKOBO.INTERNAL
   dns_lookup_realm = false
   dns_lookup_kdc = false
   rdns = false

--- a/tips/use-kerberos.md
+++ b/tips/use-kerberos.md
@@ -147,6 +147,7 @@ This is my example. Note that some domain names under `[realms]` and `[domain_re
   dns_lookup_realm = false
   dns_lookup_kdc = false
   rdns = false
+  default_realm = KUROKOBO.INTERNAL
 
 [realms]
   KUROKOBO.INTERNAL = {


### PR DESCRIPTION
This example caused the test playbook to fail with an error saying that the Kerberos config did not specify a default realm.

Once I added that extra line to the configmap, it worked great. Just thought I would contribute that back as a PR for anyone else that finds this in the future.

Thanks!