### PR TITLE
Add postgres_data_volume_init parameter to base/awx.yaml

### DIFF
--- a/argocd/example/awx.yaml
+++ b/argocd/example/awx.yaml
@@ -22,7 +22,6 @@ spec:
   task_resource_requirements: {}
   ee_resource_requirements: {}
   init_container_resource_requirements: {}
-  postgres_init_container_resource_requirements: {}
   postgres_resource_requirements: {}
   redis_resource_requirements: {}
   rsyslog_resource_requirements: {}

--- a/base/awx.yaml
+++ b/base/awx.yaml
@@ -35,10 +35,11 @@ spec:
   task_resource_requirements: {}
   ee_resource_requirements: {}
   init_container_resource_requirements: {}
-  postgres_init_container_resource_requirements: {}
   postgres_resource_requirements: {}
   redis_resource_requirements: {}
   rsyslog_resource_requirements: {}
+
+  postgres_data_volume_init: true
 
   # Uncomment to reveal "censored" logs
   #no_log: false

--- a/tips/alternative-methods.md
+++ b/tips/alternative-methods.md
@@ -136,7 +136,6 @@ AWX:
     task_resource_requirements: {}
     ee_resource_requirements: {}
     init_container_resource_requirements: {}
-    postgres_init_container_resource_requirements: {}
     postgres_resource_requirements: {}
     redis_resource_requirements: {}
     rsyslog_resource_requirements: {}

--- a/tips/troubleshooting.md
+++ b/tips/troubleshooting.md
@@ -185,7 +185,6 @@ Typical solutions are one of the following:
       task_resource_requirements: {}                      👈👈👈
       ee_resource_requirements: {}                        👈👈👈
       init_container_resource_requirements: {}            👈👈👈
-      postgres_init_container_resource_requirements: {}   👈👈👈
       postgres_resource_requirements: {}                  👈👈👈
       redis_resource_requirements: {}                     👈👈👈
       rsyslog_resource_requirements: {}                   👈👈👈


### PR DESCRIPTION
Follow-up for this PR in the awx-operator repo.
* https://github.com/ansible/awx-operator/pull/1805/

This PR adds the `postgres_data_volume_init` parameter to `base/awx.yaml`.

It also removes references to the `postgres_init_container_resource_requirements` parameter, which is now deprecated.  `postgres_resource_requirements` should be used instead.