### PR TITLE
fix: unintended version specification in execution-environment.yml

### DIFF
--- a/builder/execution-environment.yml
+++ b/builder/execution-environment.yml
@@ -28,9 +28,9 @@ dependencies:
     package_system: python3.11
     python_path: /usr/bin/python3.11
   ansible_core:
-    package_pip: ansible-core~=2.15
+    package_pip: ansible-core~=2.15.0
   ansible_runner:
-    package_pip: ansible-runner~=2.3
+    package_pip: ansible-runner~=2.3.0
   system: dependencies/bindep.txt
   python: dependencies/requirements.txt
   galaxy: dependencies/requirements.yml


### PR DESCRIPTION
### Problem

The current version specification, according to [PEP 440](https://peps.python.org/pep-0440/#compatible-release), would match the following versions:

```
ansible-core >= 2.15 (aka == 2.*)
ansible-runner >= 2.3 (aka == 2.*)
```

Which would install the following versions atm:

```log
#8 1.077 Collecting ansible-core~=2.15
#8 1.234   Downloading ansible_core-2.17.3-py3-none-any.whl (2.2 MB)
#8 1.538      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.2/2.2 MB 7.4 MB/s eta 0:00:00
#8 1.785 Collecting ansible-runner~=2.3
#8 1.823   Downloading ansible_runner-2.4.0-py3-none-any.whl (79 kB)
#8 1.831      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79.7/79.7 kB 13.8 MB/s eta 0:00:00
```

However, according to [this line](https://github.com/kurokobo/awx-on-k3s/blob/7b05017a382839186ffe99ee63039c9bea5cf7c6/builder/README.md?plain=1#L79) and the container name, I assume that you wanted to build 2.15.* instead of the latest 2.* ee.

Having the latest versions installed caused a serious compatibility break on old systems (specifically, CentOS 7) because they usually have Python 3.6 installed, and according to [ansible-core release note](https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_17.html#id6) and [ansible-runner release note](https://github.com/ansible/ansible-runner/releases/tag/2.4.0), these would fail on Python 3.6 (throw Syntax Errors).

### Solution

This PR fixes the version specifications so they would install the following versions instead:

```log
#8 0.916 Collecting ansible-core~=2.15.0
#8 1.072   Downloading ansible_core-2.15.12-py3-none-any.whl (2.3 MB)
#8 1.380      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.3/2.3 MB 7.4 MB/s eta 0:00:00
#8 1.627 Collecting ansible-runner~=2.3.0
#8 1.665   Downloading ansible_runner-2.3.6-py3-none-any.whl (81 kB)
#8 1.673      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 81.6/81.6 kB 18.6 MB/s eta 0:00:00
```
